### PR TITLE
[BUGFIX] Allow Rila\Taxonomy::all($taxonomy)

### DIFF
--- a/classes/class-taxonomy.php
+++ b/classes/class-taxonomy.php
@@ -248,7 +248,7 @@ class Taxonomy extends Item {
 	 *
 	 * @return Taxonomy[]
 	 */
-	public static function all() {
-		return new Terms( array( 'taxonomy' => 'event-category' ) );
+	public static function all( $taxonomy = 'category') {
+		return new Terms( array( 'taxonomy' => $taxonomy ) );
 	}
 }


### PR DESCRIPTION
Remove hard-coded taxonomy from generic class