### PR TITLE
Allow builder render method to receive extra data

### DIFF
--- a/classes/class-builder.php
+++ b/classes/class-builder.php
@@ -169,10 +169,16 @@ class Builder implements \Iterator, \Countable {
 	 *
 	 * @return string The full HTML of the builder and its blocks.
 	 */
-	public function render() {
+	public function render($extra = array()) {
 		$this->init();
 		$out     = '';
 		$of_type = array();
+
+		if (! empty($extra)) {
+			$this->data = array_map(function($block) use ($extra) {
+				return array_merge($block, $extra);
+			}, $this->data);
+		}
 
 		foreach( $this->blocks as $index => $block ) {
 			$simplified = rila_cleanup_class( get_class( $block ), 'Block' );


### PR DESCRIPTION
This would make it possible to pass some extra arguments to the block:

```php
    {{ blocks.render({ some: 'data' }) }}
```

This might be a very edge case, but I actually had nested content, where it would have been useful to know some info about the parent.

I believe this shouldn't break any existing functionality.